### PR TITLE
support error handling in Jasmine

### DIFF
--- a/wdio.js
+++ b/wdio.js
@@ -68,7 +68,11 @@ exports.wrap = function wrap(code) {
                 code.call(self);
                 callback();
             } catch (error) {
-                callback(error);
+                if (callback.fail) {
+                  callback.fail(error)
+                } else {
+                  callback(error);
+                }
             }
         }).run();
     }


### PR DESCRIPTION
Jasmine doesn't support calling `done` with error parameter. It uses `done.fail` instead.