### PR TITLE
Update fibers version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -469,9 +469,9 @@
       }
     },
     "fibers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-3.1.1.tgz",
-      "integrity": "sha512-dl3Ukt08rHVQfY8xGD0ODwyjwrRALtaghuqGH2jByYX1wpY+nAnRQjJ6Dbqq0DnVgNVQ9yibObzbF4IlPyiwPw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.2.tgz",
+      "integrity": "sha512-FhICi1K4WZh9D6NC18fh2ODF3EWy1z0gzIdV9P7+s2pRjfRBnCkMDJ6x3bV1DkVymKH8HGrQa/FNOBjYvnJ/tQ==",
       "requires": {
         "detect-libc": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wdio",
   "version": "3.0.3",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
   "author": "Mateusz Zieliński <mateusz.mzielinski@gmail.com> (https://github.com/ziolko)",
   "license": "MIT",
   "dependencies": {
-    "fibers": "^3.0.0",
+    "fibers": "^4.0.2",
     "selenium-standalone": "^6.15.4",
     "tcp-port-used": "^1.0.1",
     "webdriverio": "^4.12.0"


### PR DESCRIPTION
This PR updates `fibers` to `4.0.2` as `3.0.0` has issues installing on Node 12.

See https://github.com/laverdet/node-fibers/issues/409.